### PR TITLE
Scaffold: Quality of life improvements for the Scaffold feature

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -76,7 +76,7 @@ apply(plugin = "com.jetbrains.rdgen")
 configure<com.jetbrains.rd.generator.gradle.RdGenExtension> {
     val modelDir = file("$projectDir/protocol/src/main/kotlin/model")
     val csOutput = file("$projectDir/src/dotnet/$dotnetPluginId/Rd")
-    val ktOutput = file("$projectDir/src/rider/main/kotlin/${riderPluginId.replace('.','/').toLowerCase()}/rd")
+    val ktOutput = file("$projectDir/src/rider/main/kotlin/${riderPluginId.replace('.','/').lowercase()}/rd")
 
     verbose = true
     classpath({

--- a/src/rider/main/kotlin/com/jetbrains/observables/ObservableCollection.kt
+++ b/src/rider/main/kotlin/com/jetbrains/observables/ObservableCollection.kt
@@ -1,10 +1,10 @@
 package com.jetbrains.observables
 
-open class ObservableCollection<T>(initialCollection: List<T> = listOf()) : com.jetbrains.observables.ObservableProperty<List<T>>(initialCollection), MutableList<T> {
+open class ObservableCollection<T>(initialCollection: List<T> = listOf()) : ObservableProperty<List<T>>(initialCollection), MutableList<T> {
     private var items = initialCollection.toMutableList()
 
-    val onAdded: com.jetbrains.observables.Event<T> = com.jetbrains.observables.Event()
-    val onRemoved: com.jetbrains.observables.Event<T> = com.jetbrains.observables.Event()
+    val onAdded: Event<T> = Event()
+    val onRemoved: Event<T> = Event()
 
     fun afterAdded(effect: (T) -> Unit) {
         onAdded += effect
@@ -38,10 +38,10 @@ open class ObservableCollection<T>(initialCollection: List<T> = listOf()) : com.
     }
 
     override fun addAll(elements: Collection<T>): Boolean {
-        var changed = false
-        elements.forEach {
-            if (this.add(it)) {
-                changed = true
+        val changed = items.addAll(elements)
+        if (changed) {
+            elements.forEach {
+                onAdded.invoke(it)
             }
         }
 
@@ -61,10 +61,10 @@ open class ObservableCollection<T>(initialCollection: List<T> = listOf()) : com.
     }
 
     override fun removeAll(elements: Collection<T>): Boolean {
-        var removed = false
-        elements.forEach {
-            if (this.remove(it)) {
-                removed = true
+        val removed = items.removeAll(elements)
+        if (removed) {
+            elements.forEach {
+                onRemoved.invoke(it)
             }
         }
 
@@ -75,9 +75,11 @@ open class ObservableCollection<T>(initialCollection: List<T> = listOf()) : com.
         get() = items.size
 
     override fun addAll(index: Int, elements: Collection<T>): Boolean {
-        var changed = false
-        for (element in elements) {
-            changed = add(element)
+        val changed = items.addAll(index, elements)
+        if (changed) {
+            elements.forEach {
+                onAdded.invoke(it)
+            }
         }
 
         return changed

--- a/src/rider/main/kotlin/com/jetbrains/rider/plugins/efcore/cli/api/DbContextCommandFactory.kt
+++ b/src/rider/main/kotlin/com/jetbrains/rider/plugins/efcore/cli/api/DbContextCommandFactory.kt
@@ -31,11 +31,9 @@ class DbContextCommandFactory(private val intellijProject: Project) {
             }
 
             if (!scaffoldAllTables) {
-                tablesList.forEach {
-                    if (it.isEmpty()) return@forEach
-
-                    addNamed("--table", it)
-                }
+                tablesList
+                    .filter { it.isNotEmpty() }
+                    .forEach { addNamed("--table", it) }
             }
 
             addIf("--use-database-names", useDatabaseNames)

--- a/src/rider/main/kotlin/com/jetbrains/rider/plugins/efcore/cli/api/DbContextCommandFactory.kt
+++ b/src/rider/main/kotlin/com/jetbrains/rider/plugins/efcore/cli/api/DbContextCommandFactory.kt
@@ -32,6 +32,8 @@ class DbContextCommandFactory(private val intellijProject: Project) {
 
             if (!scaffoldAllTables) {
                 tablesList.forEach {
+                    if (it.isEmpty()) return@forEach
+
                     addNamed("--table", it)
                 }
             }

--- a/src/rider/main/kotlin/com/jetbrains/rider/plugins/efcore/features/dbcontext/scaffold/ScaffoldDbContextDataContext.kt
+++ b/src/rider/main/kotlin/com/jetbrains/rider/plugins/efcore/features/dbcontext/scaffold/ScaffoldDbContextDataContext.kt
@@ -85,6 +85,13 @@ class ScaffoldDbContextDataContext(intellijProject: Project) : CommonDataContext
             tablesList.addAll(this.split(',').map { SimpleItem(it) })
             scaffoldAllTables.value = this.isEmpty()
         }
+
+        commonDialogState.get(KnownStateKeys.SCHEMAS)?.apply {
+            // We assign the value directly as a listOf() because using tablesList.removeAll() causes the menu to not open at all
+            schemasList.value = mutableListOf()
+            schemasList.addAll(this.split(',').map { SimpleItem(it) })
+            scaffoldAllSchemas.value = this.isEmpty()
+        }
     }
 
     override fun saveState(commonDialogState: DialogsStateService.SpecificDialogState) {
@@ -103,8 +110,11 @@ class ScaffoldDbContextDataContext(intellijProject: Project) : CommonDataContext
         commonDialogState.set(KnownStateKeys.DB_CONTEXT_NAME, dbContextName.value)
         commonDialogState.set(KnownStateKeys.DB_CONTEXT_FOLDER, dbContextFolder.value)
 
-         val filteredTables = tablesList.value.filter { it.data.isNotEmpty() }
-         commonDialogState.set(KnownStateKeys.TABLES, filteredTables.joinToString { it.data })
+        val filteredTables = tablesList.value.filter { it.data.isNotEmpty() }
+        commonDialogState.set(KnownStateKeys.TABLES, filteredTables.joinToString { it.data })
+
+        val filteredSchemas = schemasList.value.filter { it.data.isNotEmpty() }
+        commonDialogState.set(KnownStateKeys.SCHEMAS, filteredSchemas.joinToString { it.data })
     }
 
     object KnownStateKeys {
@@ -128,5 +138,7 @@ class ScaffoldDbContextDataContext(intellijProject: Project) : CommonDataContext
         const val DB_CONTEXT_FOLDER = "dbContextFolder"
         @NonNls
         const val TABLES = "tables"
+        @NonNls
+        const val SCHEMAS = "schemas"
     }
 }

--- a/src/rider/main/kotlin/com/jetbrains/rider/plugins/efcore/features/dbcontext/scaffold/ScaffoldDbContextDataContext.kt
+++ b/src/rider/main/kotlin/com/jetbrains/rider/plugins/efcore/features/dbcontext/scaffold/ScaffoldDbContextDataContext.kt
@@ -1,7 +1,6 @@
 package com.jetbrains.rider.plugins.efcore.features.dbcontext.scaffold
 
 import com.intellij.openapi.project.Project
-import com.intellij.util.containers.init
 import com.jetbrains.observables.observable
 import com.jetbrains.observables.observableList
 import com.jetbrains.rider.plugins.efcore.features.shared.ObservableConnections
@@ -79,6 +78,13 @@ class ScaffoldDbContextDataContext(intellijProject: Project) : CommonDataContext
         commonDialogState.get(KnownStateKeys.DB_CONTEXT_FOLDER)?.apply {
             dbContextFolder.value = this
         }
+
+        commonDialogState.get(KnownStateKeys.TABLES)?.apply {
+            // We assign the value directly as a listOf() because using tablesList.removeAll() causes the menu to not open at all
+            tablesList.value = listOf()
+            tablesList.addAll(this.split(',').map { SimpleItem(it) })
+            scaffoldAllTables.value = this.isEmpty()
+        }
     }
 
     override fun saveState(commonDialogState: DialogsStateService.SpecificDialogState) {
@@ -96,6 +102,9 @@ class ScaffoldDbContextDataContext(intellijProject: Project) : CommonDataContext
         commonDialogState.set(KnownStateKeys.USE_PLURALIZER, usePluralizer.value)
         commonDialogState.set(KnownStateKeys.DB_CONTEXT_NAME, dbContextName.value)
         commonDialogState.set(KnownStateKeys.DB_CONTEXT_FOLDER, dbContextFolder.value)
+
+         val filteredTables = tablesList.value.filter { it.data.isNotEmpty() }
+         commonDialogState.set(KnownStateKeys.TABLES, filteredTables.joinToString { it.data })
     }
 
     object KnownStateKeys {
@@ -117,5 +126,7 @@ class ScaffoldDbContextDataContext(intellijProject: Project) : CommonDataContext
         const val DB_CONTEXT_NAME = "dbContextName"
         @NonNls
         const val DB_CONTEXT_FOLDER = "dbContextFolder"
+        @NonNls
+        const val TABLES = "tables"
     }
 }

--- a/src/rider/main/kotlin/com/jetbrains/rider/plugins/efcore/features/dbcontext/scaffold/ScaffoldDbContextDataContext.kt
+++ b/src/rider/main/kotlin/com/jetbrains/rider/plugins/efcore/features/dbcontext/scaffold/ScaffoldDbContextDataContext.kt
@@ -11,6 +11,8 @@ import com.jetbrains.rider.plugins.efcore.ui.items.SimpleItem
 import org.jetbrains.annotations.NonNls
 
 class ScaffoldDbContextDataContext(intellijProject: Project) : CommonDataContext(intellijProject, false) {
+    private val listSeparator = "@_#@@"
+
     val connection = observable("")
     val observableConnections = ObservableConnections(intellijProject, startupProject)
     val provider = observable("")
@@ -80,16 +82,14 @@ class ScaffoldDbContextDataContext(intellijProject: Project) : CommonDataContext
         }
 
         commonDialogState.get(KnownStateKeys.TABLES)?.apply {
-            // We assign the value directly as a listOf() because using tablesList.removeAll() causes the menu to not open at all
-            tablesList.value = mutableListOf()
-            tablesList.addAll(this.split(',').map { SimpleItem(it) })
+            tablesList.clear()
+            tablesList.addAll(this.split(listSeparator).map { SimpleItem(it) })
             scaffoldAllTables.value = this.isEmpty()
         }
 
         commonDialogState.get(KnownStateKeys.SCHEMAS)?.apply {
-            // We assign the value directly as a listOf() because using tablesList.removeAll() causes the menu to not open at all
-            schemasList.value = mutableListOf()
-            schemasList.addAll(this.split(',').map { SimpleItem(it) })
+            schemasList.clear()
+            schemasList.addAll(this.split(listSeparator).map { SimpleItem(it) })
             scaffoldAllSchemas.value = this.isEmpty()
         }
     }
@@ -111,10 +111,10 @@ class ScaffoldDbContextDataContext(intellijProject: Project) : CommonDataContext
         commonDialogState.set(KnownStateKeys.DB_CONTEXT_FOLDER, dbContextFolder.value)
 
         val filteredTables = tablesList.value.filter { it.data.isNotEmpty() }
-        commonDialogState.set(KnownStateKeys.TABLES, filteredTables.joinToString { it.data })
+        commonDialogState.set(KnownStateKeys.TABLES, filteredTables.joinToString(listSeparator) { it.data })
 
         val filteredSchemas = schemasList.value.filter { it.data.isNotEmpty() }
-        commonDialogState.set(KnownStateKeys.SCHEMAS, filteredSchemas.joinToString { it.data })
+        commonDialogState.set(KnownStateKeys.SCHEMAS, filteredSchemas.joinToString(listSeparator) { it.data })
     }
 
     object KnownStateKeys {

--- a/src/rider/main/kotlin/com/jetbrains/rider/plugins/efcore/features/dbcontext/scaffold/ScaffoldDbContextDataContext.kt
+++ b/src/rider/main/kotlin/com/jetbrains/rider/plugins/efcore/features/dbcontext/scaffold/ScaffoldDbContextDataContext.kt
@@ -81,7 +81,7 @@ class ScaffoldDbContextDataContext(intellijProject: Project) : CommonDataContext
 
         commonDialogState.get(KnownStateKeys.TABLES)?.apply {
             // We assign the value directly as a listOf() because using tablesList.removeAll() causes the menu to not open at all
-            tablesList.value = listOf()
+            tablesList.value = mutableListOf()
             tablesList.addAll(this.split(',').map { SimpleItem(it) })
             scaffoldAllTables.value = this.isEmpty()
         }

--- a/src/rider/main/kotlin/com/jetbrains/rider/plugins/efcore/features/dbcontext/scaffold/ScaffoldDbContextDialogWrapper.kt
+++ b/src/rider/main/kotlin/com/jetbrains/rider/plugins/efcore/features/dbcontext/scaffold/ScaffoldDbContextDialogWrapper.kt
@@ -12,10 +12,7 @@ import com.intellij.ui.dsl.builder.*
 import com.intellij.ui.layout.not
 import com.intellij.ui.layout.selected
 import com.intellij.ui.table.JBTable
-import com.jetbrains.observables.ObservableProperty
-import com.jetbrains.observables.bind
-import com.jetbrains.observables.observable
-import com.jetbrains.observables.observableList
+import com.jetbrains.observables.*
 import com.jetbrains.rider.plugins.efcore.cli.api.DbContextCommandFactory
 import com.jetbrains.rider.plugins.efcore.cli.api.models.DotnetEfVersion
 import com.jetbrains.rider.plugins.efcore.features.shared.dialog.CommonDialogWrapper
@@ -221,14 +218,15 @@ class ScaffoldDbContextDialogWrapper(
     }
 
     private fun createTablesTab(): DialogPanel =
-        createToggleableTablePanel(tablesModel, EfCoreUiBundle.message("checkbox.scaffold.all.tables"), dataCtx.scaffoldAllTables)
+        createToggleableTablePanel(tablesModel, EfCoreUiBundle.message("checkbox.scaffold.all.tables"), dataCtx.tablesList, dataCtx.scaffoldAllTables)
 
     private fun createSchemasTab(): DialogPanel =
-        createToggleableTablePanel(schemasModel, EfCoreUiBundle.message("checkbox.scaffold.all.schemas"), dataCtx.scaffoldAllSchemas)
+        createToggleableTablePanel(schemasModel, EfCoreUiBundle.message("checkbox.scaffold.all.schemas"), dataCtx.schemasList, dataCtx.scaffoldAllSchemas)
 
     private fun createToggleableTablePanel(
         tableModel: SimpleListTableModel,
         checkboxText: String,
+        items: ObservableCollection<SimpleItem>,
         checkboxProperty: ObservableProperty<Boolean>
     ): DialogPanel {
         val table = JBTable(tableModel)
@@ -262,12 +260,12 @@ class ScaffoldDbContextDialogWrapper(
             tablePanel.isVisible = !enabledCheckbox!!.isSelected
 
             row {
-                val scaffoldAllTables = enabledCheckbox!!.selected
+                val scaffoldAll = enabledCheckbox!!.selected
                 cell(tablePanel)
                     .align(Align.FILL)
-                    .enabledIf(scaffoldAllTables.not())
-                    .validationOnInput(validator.tablesValidation(dataCtx.tablesList, scaffoldAllTables))
-                    .validationOnApply(validator.tablesValidation(dataCtx.tablesList, scaffoldAllTables))
+                    .enabledIf(scaffoldAll.not())
+                    .validationOnInput(validator.tableSchemaValidation(items, scaffoldAll))
+                    .validationOnApply(validator.tableSchemaValidation(items, scaffoldAll))
             }.resizableRow()
         }
     }

--- a/src/rider/main/kotlin/com/jetbrains/rider/plugins/efcore/features/dbcontext/scaffold/ScaffoldDbContextDialogWrapper.kt
+++ b/src/rider/main/kotlin/com/jetbrains/rider/plugins/efcore/features/dbcontext/scaffold/ScaffoldDbContextDialogWrapper.kt
@@ -264,7 +264,6 @@ class ScaffoldDbContextDialogWrapper(
                 cell(tablePanel)
                     .align(Align.FILL)
                     .enabledIf(scaffoldAll.not())
-                    .validationOnInput(validator.tableSchemaValidation(items, scaffoldAll))
                     .validationOnApply(validator.tableSchemaValidation(items, scaffoldAll))
             }.resizableRow()
         }

--- a/src/rider/main/kotlin/com/jetbrains/rider/plugins/efcore/features/dbcontext/scaffold/ScaffoldDbContextDialogWrapper.kt
+++ b/src/rider/main/kotlin/com/jetbrains/rider/plugins/efcore/features/dbcontext/scaffold/ScaffoldDbContextDialogWrapper.kt
@@ -262,9 +262,12 @@ class ScaffoldDbContextDialogWrapper(
             tablePanel.isVisible = !enabledCheckbox!!.isSelected
 
             row {
+                val scaffoldAllTables = enabledCheckbox!!.selected
                 cell(tablePanel)
                     .align(Align.FILL)
-                    .enabledIf(enabledCheckbox!!.selected.not())
+                    .enabledIf(scaffoldAllTables.not())
+                    .validationOnInput(validator.tablesValidation(dataCtx.tablesList, scaffoldAllTables))
+                    .validationOnApply(validator.tablesValidation(dataCtx.tablesList, scaffoldAllTables))
             }.resizableRow()
         }
     }

--- a/src/rider/main/kotlin/com/jetbrains/rider/plugins/efcore/features/dbcontext/scaffold/ScaffoldDbContextDialogWrapper.kt
+++ b/src/rider/main/kotlin/com/jetbrains/rider/plugins/efcore/features/dbcontext/scaffold/ScaffoldDbContextDialogWrapper.kt
@@ -204,7 +204,7 @@ class ScaffoldDbContextDialogWrapper(
                 .bindText(dataCtx.dbContextName)
                 .align(AlignX.FILL)
                 .validationOnInput(validator.dbContextNameValidation())
-                .validationOnInput(validator.dbContextNameValidation())
+                .validationOnApply(validator.dbContextNameValidation())
         }
 
         row(EfCoreUiBundle.message("generated.dbcontext.folder")) {
@@ -215,7 +215,7 @@ class ScaffoldDbContextDialogWrapper(
                 .bindText(dataCtx.dbContextFolder)
                 .align(AlignX.FILL)
                 .validationOnInput(validator.dbContextFolderValidation())
-                .validationOnInput(validator.dbContextFolderValidation())
+                .validationOnApply(validator.dbContextFolderValidation())
                 .applyToComponent { dataCtx.migrationsProject.afterChange { this.isEnabled = it != null }  }
         }
     }

--- a/src/rider/main/kotlin/com/jetbrains/rider/plugins/efcore/features/dbcontext/scaffold/ScaffoldDbContextValidator.kt
+++ b/src/rider/main/kotlin/com/jetbrains/rider/plugins/efcore/features/dbcontext/scaffold/ScaffoldDbContextValidator.kt
@@ -3,10 +3,14 @@ package com.jetbrains.rider.plugins.efcore.features.dbcontext.scaffold
 import com.intellij.openapi.ui.ComboBox
 import com.intellij.openapi.ui.TextFieldWithBrowseButton
 import com.intellij.openapi.ui.ValidationInfo
+import com.intellij.ui.layout.ComponentPredicate
 import com.intellij.ui.layout.ValidationInfoBuilder
+import com.jetbrains.observables.ObservableCollection
 import com.jetbrains.rider.plugins.efcore.EfCoreUiBundle
 import com.jetbrains.rider.plugins.efcore.ui.items.DbConnectionItem
 import com.jetbrains.rider.plugins.efcore.ui.items.DbProviderItem
+import com.jetbrains.rider.plugins.efcore.ui.items.SimpleItem
+import javax.swing.JPanel
 import javax.swing.JTextField
 import javax.swing.text.JTextComponent
 
@@ -41,6 +45,12 @@ class ScaffoldDbContextValidator {
     fun dbContextFolderValidation(): ValidationInfoBuilder.(TextFieldWithBrowseButton) -> ValidationInfo? = {
         if (it.text.trim().isEmpty())
             error(EfCoreUiBundle.message("dialog.message.dbcontext.folder.could.not.be.empty"))
+    fun tablesValidation(
+        tablesList: ObservableCollection<SimpleItem>,
+        scaffoldAllTables: ComponentPredicate
+    ): ValidationInfoBuilder.(JPanel) -> ValidationInfo? = {
+        if (!scaffoldAllTables.invoke() && tablesList.none { it.data.isNotEmpty() })
+            error(EfCoreUiBundle.message("dialog.message.tables.should.not.be.empty"))
         else
             null
     }

--- a/src/rider/main/kotlin/com/jetbrains/rider/plugins/efcore/features/dbcontext/scaffold/ScaffoldDbContextValidator.kt
+++ b/src/rider/main/kotlin/com/jetbrains/rider/plugins/efcore/features/dbcontext/scaffold/ScaffoldDbContextValidator.kt
@@ -49,12 +49,12 @@ class ScaffoldDbContextValidator {
             null
     }
 
-    fun tablesValidation(
+    fun tableSchemaValidation(
         tablesList: ObservableCollection<SimpleItem>,
         scaffoldAllTables: ComponentPredicate
     ): ValidationInfoBuilder.(JPanel) -> ValidationInfo? = {
         if (!scaffoldAllTables.invoke() && tablesList.none { it.data.isNotEmpty() })
-            error(EfCoreUiBundle.message("dialog.message.tables.should.not.be.empty"))
+            error(EfCoreUiBundle.message("dialog.message.tables.schemas.should.not.be.empty"))
         else
             null
     }

--- a/src/rider/main/kotlin/com/jetbrains/rider/plugins/efcore/features/dbcontext/scaffold/ScaffoldDbContextValidator.kt
+++ b/src/rider/main/kotlin/com/jetbrains/rider/plugins/efcore/features/dbcontext/scaffold/ScaffoldDbContextValidator.kt
@@ -30,7 +30,7 @@ class ScaffoldDbContextValidator {
 
     fun outputFolderValidation(): ValidationInfoBuilder.(TextFieldWithBrowseButton) -> ValidationInfo? = {
         if (it.text.trim().isEmpty())
-            error(EfCoreUiBundle.message("dialog.message.output.folder.could.not.be.empty"))
+            error(EfCoreUiBundle.message("dialog.message.output.folder.should.not.be.empty"))
         else
             null
     }
@@ -44,7 +44,11 @@ class ScaffoldDbContextValidator {
 
     fun dbContextFolderValidation(): ValidationInfoBuilder.(TextFieldWithBrowseButton) -> ValidationInfo? = {
         if (it.text.trim().isEmpty())
-            error(EfCoreUiBundle.message("dialog.message.dbcontext.folder.could.not.be.empty"))
+            error(EfCoreUiBundle.message("dialog.message.dbcontext.folder.should.not.be.empty"))
+        else
+            null
+    }
+
     fun tablesValidation(
         tablesList: ObservableCollection<SimpleItem>,
         scaffoldAllTables: ComponentPredicate

--- a/src/rider/main/resources/messages/EfCoreUiBundle.properties
+++ b/src/rider/main/resources/messages/EfCoreUiBundle.properties
@@ -125,7 +125,7 @@ dialog.message.provider.could.not.be.empty=Provider could not be empty
 dialog.message.output.folder.should.not.be.empty=Output folder should not be empty
 dialog.message.dbcontext.class.name.could.not.be.empty=DbContext class name could not be empty
 dialog.message.dbcontext.folder.should.not.be.empty=DbContext folder should not be empty
-dialog.message.tables.should.not.be.empty=The tables list should not be empty
+dialog.message.tables.schemas.should.not.be.empty=The list should not be empty
 
 #
 # DB connections auto-completion

--- a/src/rider/main/resources/messages/EfCoreUiBundle.properties
+++ b/src/rider/main/resources/messages/EfCoreUiBundle.properties
@@ -125,6 +125,7 @@ dialog.message.provider.could.not.be.empty=Provider could not be empty
 dialog.message.output.folder.could.not.be.empty=Output folder could not be empty
 dialog.message.dbcontext.class.name.could.not.be.empty=DbContext class name could not be empty
 dialog.message.dbcontext.folder.could.not.be.empty=DbContext folder could not be empty
+dialog.message.tables.should.not.be.empty=The tables list should not be empty
 
 #
 # DB connections auto-completion

--- a/src/rider/main/resources/messages/EfCoreUiBundle.properties
+++ b/src/rider/main/resources/messages/EfCoreUiBundle.properties
@@ -122,9 +122,9 @@ select.generated.dbcontext.folder=Select Generated DbContext Folder
 checkbox.scaffold.all.tables=Scaffold all tables
 checkbox.scaffold.all.schemas=Scaffold all schemas
 dialog.message.provider.could.not.be.empty=Provider could not be empty
-dialog.message.output.folder.could.not.be.empty=Output folder could not be empty
+dialog.message.output.folder.should.not.be.empty=Output folder should not be empty
 dialog.message.dbcontext.class.name.could.not.be.empty=DbContext class name could not be empty
-dialog.message.dbcontext.folder.could.not.be.empty=DbContext folder could not be empty
+dialog.message.dbcontext.folder.should.not.be.empty=DbContext folder should not be empty
 dialog.message.tables.should.not.be.empty=The tables list should not be empty
 
 #


### PR DESCRIPTION
This PR tackles some issues from #172 by storing tables in the project settings and adding table validations. It also prevents empty row errors in the scaffold command.

Had to use `tablesList.value = listOf()` in `ScaffoldDbContextDataContext` to reset the list due to the UI state reloading often. Tried `tablesList.removeAll()`, but it stopped the tab from opening.